### PR TITLE
8354922: ZGC: Use MAP_FIXED_NOREPLACE when reserving memory

### DIFF
--- a/src/hotspot/os/linux/gc/x/xSyscall_linux.hpp
+++ b/src/hotspot/os/linux/gc/x/xSyscall_linux.hpp
@@ -35,6 +35,10 @@
 #define MPOL_F_ADDR        (1<<1)
 #endif
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 class XSyscall : public AllStatic {
 public:
   static int memfd_create(const char* name, unsigned int flags);

--- a/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
+++ b/src/hotspot/os/linux/gc/z/zSyscall_linux.hpp
@@ -35,6 +35,10 @@
 #define MPOL_F_ADDR        (1<<1)
 #endif
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 class ZSyscall : public AllStatic {
 public:
   static int memfd_create(const char* name, unsigned int flags);

--- a/src/hotspot/os/posix/gc/x/xVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/x/xVirtualMemory_posix.cpp
@@ -25,6 +25,9 @@
 #include "gc/x/xAddress.inline.hpp"
 #include "gc/x/xVirtualMemory.hpp"
 #include "logging/log.hpp"
+#ifdef LINUX
+#include "gc/x/xSyscall_linux.hpp"
+#endif
 
 #include <sys/mman.h>
 #include <sys/types.h>
@@ -38,7 +41,9 @@ void XVirtualMemoryManager::pd_initialize_after_reserve() {
 }
 
 bool XVirtualMemoryManager::pd_reserve(uintptr_t addr, size_t size) {
-  const uintptr_t res = (uintptr_t)mmap((void*)addr, size, PROT_NONE, MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE, -1, 0);
+  const int flags = MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE LINUX_ONLY(|MAP_FIXED_NOREPLACE);
+
+  const uintptr_t res = (uintptr_t)mmap((void*)addr, size, PROT_NONE, flags, -1, 0);
   if (res == (uintptr_t)MAP_FAILED) {
     // Failed to reserve memory
     return false;

--- a/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
+++ b/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp
@@ -25,6 +25,9 @@
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zVirtualMemory.hpp"
 #include "logging/log.hpp"
+#ifdef LINUX
+#include "gc/z/zSyscall_linux.hpp"
+#endif
 
 #include <sys/mman.h>
 #include <sys/types.h>
@@ -38,7 +41,9 @@ void ZVirtualMemoryManager::pd_initialize_after_reserve() {
 }
 
 bool ZVirtualMemoryManager::pd_reserve(zaddress_unsafe addr, size_t size) {
-  void* const res = mmap((void*)untype(addr), size, PROT_NONE, MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE, -1, 0);
+  const int flags = MAP_ANONYMOUS|MAP_PRIVATE|MAP_NORESERVE LINUX_ONLY(|MAP_FIXED_NOREPLACE);
+
+  void* const res = mmap((void*)untype(addr), size, PROT_NONE, flags, -1, 0);
   if (res == MAP_FAILED) {
     // Failed to reserve memory
     return false;


### PR DESCRIPTION
Hi all,

Please review the backport of JDK-8354922 to JDK 21.

There are versions of the Linux kernel that do not honor the address hint when mmapping memory without MAP_FIXED, that clobbers the older mappings overlapped with the requested range. A safer MAP_FIXED_NOREPLACE flag is used with ZGC since Java 25.

JDK 21 crashes with -XX:+UseZGC with RANDMMAP [1] kernel patch enabled, while JDK 25 works as expected.

```
$ ./25.0.1/bin/java -XX:+UseZGC -version
openjdk version "25.0.1" 2025-10-21 LTS
OpenJDK Runtime Environment (build 25.0.1+11-LTS)
OpenJDK 64-Bit Server VM (build 25.0.1+11-LTS, mixed mode, sharing)

$ ./21.0.9/bin/java -XX:+UseZGC -version
[0.070s][error][gc] Failed to reserve enough address space for Java heap
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

ZGC relies on kernel that respects address hints in mmap system call, which is not the case with RANDMMAP enabled kernels. ZVirtualMemoryManager::pd_reserve() always returns false at line 50 because the mmap returned value never matches the requested address.

https://github.com/sercher/jdk21u-dev/blob/634d3fa7f147fc6fb1a7765755a3feed82ffaf50/src/hotspot/os/posix/gc/z/zVirtualMemory_posix.cpp#L40-L51

Since Linux 4.17 there's MAP_FIXED_NOREPLACE flag in mmap, that satisfies the `addr` requests and reports failure when the requested range overlaps a pre-existing mapping.

The backport isn't clean. JDK 21 doesn't have JDK-8350441 that renamed zVirtualMemory_posix.cpp to zVirtualMemoryManager_posix.cpp, and JDK-8341692 that removed non-generational mode in ZGC. In absense of JDK-8341692 the same approach was taken on gc/x/ version of pd_reserve().

It is also proposed to backport JDK-8313319 that prevents unnecessary mmap-munmap cycle, that will follow in a separate PR (#7).

[1] https://pax.grsecurity.net/docs/randmmap.txt